### PR TITLE
Update LibQTip-1.0 repository location

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -41,8 +41,7 @@ externals:
     url: svn://svn.wowace.com/wow/ace-gui-3-0-shared-media-widgets/mainline/trunk/AceGUI-3.0-SharedMediaWidgets
     tag: latest
   libs/LibQTip-1.0:
-    url: svn://svn.wowace.com/wow/libqtip-1-0/mainline/trunk
-    tag: latest
+    url: https://repos.wowace.com/wow/libqtip-1-0
   modules/MicroMenu:
     url: https://github.com/zanony/Broker_MicroMenu.git
     tag: latest


### PR DESCRIPTION
LibQTip moved to Git a while ago, and they are unfortunately not providing a 9.0 compatible tag at this time (alphas are fine though), update the pkgmeta to account for this.